### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT MSVC)
 endif()
 
 set(release-name "ome-cmake-superbuild")
-set(release-version "0.5.0")
+set(release-version "0.5.1")
 project("${release-name}"
   VERSION "${release-version}"
   LANGUAGES CXX)


### PR DESCRIPTION
Following the release of [OME Files 0.5.0](http://www.openmicroscopy.org/2017/12/04/ome-files-0-5-0.html), this PR increments the patch number

See also https://github.com/openmicroscopy/ome-documentation/pull/1819